### PR TITLE
chardet 5.1.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.0.0" %}
+{% set version = "5.1.0" %}
 
 package:
   name: chardet
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/chardet/chardet-{{ version }}.tar.gz
-  sha256: 0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa
+  sha256: 0d62712b956bc154f85fb0a266e2a3c5913c2967e00348701b32411d6def31e5
 
 build:
   number: 1003


### PR DESCRIPTION
**Recipe directory diff between current master and this update:**
``` diff
diff --git a/recipe/meta.yaml b/recipe/meta.yaml
index 0e9d8fa..db61cad 100644
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.0.0" %}
+{% set version = "5.1.0" %}
 
 package:
   name: chardet
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/c/chardet/chardet-{{ version }}.tar.gz
-  sha256: 0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa
+  sha256: 0d62712b956bc154f85fb0a266e2a3c5913c2967e00348701b32411d6def31e5
 
 build:
   number: 1003

```

**Jira ticket:** [PKG-303](https://anaconda.atlassian.net/browse/PKG-303) (chardet-5.0.0)

**The upstream data:**
Github releases:  https://github.com/chardet/chardet/releases
[Diff between the latest and previous upstream releases](https://github.com/chardet/chardet/compare/4.0.0...5.1.0)
Requirements:
 * setup.cfg:  https://github.com/chardet/chardet/blob/5.1.0/setup.cfg
 * pyproject.toml:  https://github.com/chardet/chardet/blob/5.1.0/pyproject.toml

**_Actions:_**

1. 

**_Notes:_**
 * 

**Additional info:**

<details>

**Package's statistics**

<details>

 * Priority C | effort: easy | Category: miniconda | subcategory: dependency | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 5.1.0
 * Release on PyPi:
    * version: 5.1.0
    * date: 2022-12-01T22:34:18
* [PyPi history](https://pypi.org/project/chardet/#history)
 * Popularity: 
    * 3 months downloads: 1589747.0
    * All time:  19102807 downloads -  chardet  5.1.0  Universal character encoding detector  

</details>

**Other checks:**

<details>

1. - [ ] Check the pinnings
2. - [ ] Verify that the `build_number` is correct
4. - [ ] Verify if the package needs `setuptools`
    
6. - [ ] Verify if the package needs `wheel`
    
8. - [ ] NO `pip` in test
    
9. - [ ] Verify the test section
10. - [ ] Verify if the package is `architecture specific`
11. - [ ] Verify that private modules are not mentioned in the recipe For example: (_private_module)
12.  - [x] license_file: LICENSE is present

14. - [x] license_family GPL is present
16. - [x] License: LGPL2
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier   |
|--------------|
</details>

**Check dependency issues:**

<details>
../aggregate/chardet-feedstock/recipe/meta.yaml
Dependencies: ['python', 'pytest-runner', 'pip']


noarch:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-ppc64le:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

linux-s390x:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

osx-arm64:
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

win-64:
- py3.7:  No issues found
- py3.8:  No issues found
- py3.9:  No issues found
- py3.10:  No issues found

</details>

**Package Build Score: 19**


</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/chardet-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/chardet-feedstock/tree/5.1.0)
* [conda-forge recipe](https://github.com/conda-forge/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/chardet)
* [Diff between upstream and feature branch](https://github.com/conda-forge/chardet-feedstock/compare/main...AnacondaRecipes:5.1.0)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/chardet-feedstock/compare/master...AnacondaRecipes:5.1.0)
* [The last merged PRs](https://github.com/AnacondaRecipes/chardet-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 5.1.0 git@github.com:AnacondaRecipes/chardet-feedstock.git
```
