### PR TITLE
chardet 5.2.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,13 @@ requirements:
   run:
     - python
 
+# Win64 some encodings tests failed
+# tests\\iso-8859-9-turkish\\wikitop_tr_ISO-8859-9.txt-iso-8859-9]
+{% set skip_broken_tests = [
+    "test_encoding_detection",
+    "test_encoding_detection_rename_legacy"
+] %}
+
 test:
   source_files:
     - tests
@@ -39,13 +46,12 @@ test:
   requires:
     - pip
     - pytest
-    - pytest-xdist
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - chardetect --help
-    - pytest -n auto test.py -vv --color=yes  # [not win]
-    - pytest -n auto test.py -vv -k "not test_encoding_detection and not test_encoding_detection_rename_legacy"  # [win]
+    # - pytest test.py -vv --color=yes  # [not win]
+    - pytest -vv -ra --full-trace --showlocals --maxfail=1 test.py -k "not ({{ skip_broken_tests | join(' or ') }})"  # [win]
 
 about:
   home: https://github.com/chardet/chardet

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,13 +25,6 @@ requirements:
   run:
     - python
 
-# Win64 some encodings tests failed
-# tests\\iso-8859-9-turkish\\wikitop_tr_ISO-8859-9.txt-iso-8859-9]
-{% set skip_broken_tests = [
-    "test_encoding_detection",
-    "test_encoding_detection_rename_legacy"
-] %}
-
 test:
   source_files:
     - tests
@@ -53,11 +46,7 @@ test:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - chardetect --help
-    - copy recipe_conftest.py conftest.py  # [win]
-    - cp recipe_conftest.py conftest.py    # [not win]
     - pytest -n auto -vv --color=yes test.py
-    # - pytest test.py -vv --color=yes  # [not win]
-    # - pytest -vv -ra --full-trace --showlocals --maxfail=1 test.py -k "not ({{ skip_broken_tests | join(' or ') }})"  # [win]
 
 about:
   home: https://github.com/chardet/chardet

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,6 +25,13 @@ requirements:
   run:
     - python
 
+# Win64 some encodings tests failed
+# tests\\iso-8859-9-turkish\\wikitop_tr_ISO-8859-9.txt-iso-8859-9]
+{% set skip_broken_tests = [
+    "test_encoding_detection",
+    "test_encoding_detection_rename_legacy"
+] %}
+
 test:
   source_files:
     - tests
@@ -44,7 +51,8 @@ test:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - chardetect --help
-    - pytest -n auto test.py -vv --color=yes
+    - pytest -n auto test.py -vv --color=yes  # [not win]
+    - pytest -n auto test.py -vv --color=yes -k "not ({{ skip_broken_tests | join(' or ') }})"  # [win]
 
 about:
   home: https://github.com/chardet/chardet
@@ -56,7 +64,7 @@ about:
     Chardet is a character encoding detector for Python. It supports a wide range of encodings,
     including ASCII, UTF variants, various East Asian encodings (EUC, ISO-2022, Shift_JIS),
     and many others. Chardet uses statistical models and heuristics to guess the most likely encoding.
-  doc_url: https://chardet.readthedocs.org
+  doc_url: https://chardet.readthedocs.io
   dev_url: https://github.com/chardet/chardet
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,13 +46,12 @@ test:
   requires:
     - pip
     - pytest
-    - pytest-xdist
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - chardetect --help
-    - pytest -n auto test.py -vv --color=yes  # [not win]
-    - pytest -p no:xdist test.py -vv -k "{{ ignore_tests }}"  # [win]
+    - pytest test.py -vv --color=yes  # [not win]
+    - pytest test.py -vv --maxfail=1 -x -k "{{ ignore_tests }}"  # [win]
 
 about:
   home: https://github.com/chardet/chardet

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,6 +36,8 @@ test:
   source_files:
     - tests
     - test.py
+  files:
+    - recipe_conftest.py
   imports:
     - chardet
     - chardet.metadata
@@ -46,12 +48,16 @@ test:
   requires:
     - pip
     - pytest
+    - pytest-xdist
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - chardetect --help
+    - copy recipe_conftest.py conftest.py  # [win]
+    - cp recipe_conftest.py conftest.py    # [not win]
+    - pytest -n auto -vv --color=yes test.py
     # - pytest test.py -vv --color=yes  # [not win]
-    - pytest -vv -ra --full-trace --showlocals --maxfail=1 test.py -k "not ({{ skip_broken_tests | join(' or ') }})"  # [win]
+    # - pytest -vv -ra --full-trace --showlocals --maxfail=1 test.py -k "not ({{ skip_broken_tests | join(' or ') }})"  # [win]
 
 about:
   home: https://github.com/chardet/chardet

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,18 @@
-{% set version = "4.0.0" %}
+{% set name = "chardet" %}
+{% set version = "5.2.0" %}
 
 package:
-  name: chardet
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/c/chardet/chardet-{{ version }}.tar.gz
-  sha256: 0d6f53a15db4120f2b08c94f11e7d93d2c911ee118b6b30a04ec3ee8310179fa
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 1b3b6ff479a8c414bc3fa2c0852995695c4a026dcd6d0633b2dd092ca39c1cf7
 
 build:
-  number: 1003
-  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
+  number: 0
+  skip: True  # [py<37]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation --ignore-installed --no-cache-dir -vv
   entry_points:
     - chardetect = chardet.cli.chardetect:main
 
@@ -18,26 +20,31 @@ requirements:
   host:
     - python
     - pip
-    - pytest-runner
+    - setuptools
+    - wheel
   run:
     - python
 
 test:
   imports:
     - chardet
+    - chardet.metadata
+    - chardet.sbcharsetprober
+  requires:
+    - pip
   commands:
+    - pip check
     - chardetect --help
 
 about:
   home: https://github.com/chardet/chardet
-  license: LGPL2
+  license: NGPL
   license_family: GPL
   license_file: LICENSE
   summary: Universal character encoding detector
   description: |
     chardet is a character encoding auto-detector in Python.
-  doc_url: http://chardet.readthedocs.org/
-  doc_source_url: https://github.com/chardet/chardet/blob/master/docs/index.rst
+  doc_url: https://chardet.readthedocs.org
   dev_url: https://github.com/chardet/chardet
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,13 +25,6 @@ requirements:
   run:
     - python
 
-# Win64 some encodings tests failed
-# tests\\iso-8859-9-turkish\\wikitop_tr_ISO-8859-9.txt-iso-8859-9]
-{% set ignore_tests = "not (" %}
-{% set ignore_tests = ignore_tests + "test_encoding_detection or " %}
-{% set ignore_tests = ignore_tests + "test_encoding_detection_rename_legacy or " %}
-{% set ignore_tests = ignore_tests + ")" %}
-
 test:
   source_files:
     - tests
@@ -46,12 +39,13 @@ test:
   requires:
     - pip
     - pytest
+    - pytest-xdist
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - chardetect --help
-    - pytest test.py -vv --color=yes  # [not win]
-    - pytest test.py -vv --maxfail=1 -x -k "{{ ignore_tests }}"  # [win]
+    - pytest -n auto test.py -vv --color=yes  # [not win]
+    - pytest -n auto test.py -vv -k "not test_encoding_detection and not test_encoding_detection_rename_legacy"  # [win]
 
 about:
   home: https://github.com/chardet/chardet

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,6 +46,7 @@ test:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - chardetect --help
+    - copy recipe_conftest.py conftest.py  # [win]
     - pytest -n auto -vv --color=yes test.py
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,7 +52,7 @@ test:
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - chardetect --help
     - pytest -n auto test.py -vv --color=yes  # [not win]
-    - pytest -n auto test.py -vv -k "{{ ignore_tests }}"  # [win]
+    - pytest -p no:xdist test.py -vv -k "{{ ignore_tests }}"  # [win]
 
 about:
   home: https://github.com/chardet/chardet

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,10 +27,10 @@ requirements:
 
 # Win64 some encodings tests failed
 # tests\\iso-8859-9-turkish\\wikitop_tr_ISO-8859-9.txt-iso-8859-9]
-{% set skip_broken_tests = [
-    "test_encoding_detection",
-    "test_encoding_detection_rename_legacy"
-] %}
+{% set ignore_tests = "not (" %}
+{% set ignore_tests = ignore_tests + "test_encoding_detection or " %}
+{% set ignore_tests = ignore_tests + "test_encoding_detection_rename_legacy or " %}
+{% set ignore_tests = ignore_tests + ")" %}
 
 test:
   source_files:
@@ -46,13 +46,13 @@ test:
   requires:
     - pip
     - pytest
-    # - pytest-xdist
+    - pytest-xdist
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - chardetect --help
-    - pytest test.py -vv --color=yes  # [not win]
-    - pytest test.py -vv --color=yes -k "not ({{ skip_broken_tests | join(' or ') }})"  # [win]
+    - pytest -n auto test.py -vv --color=yes  # [not win]
+    - pytest -n auto test.py -vv -k "{{ ignore_tests }}"  # [win]
 
 about:
   home: https://github.com/chardet/chardet

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,27 +26,38 @@ requirements:
     - python
 
 test:
+  source_files:
+    - tests
+    - test.py
   imports:
     - chardet
     - chardet.metadata
     - chardet.sbcharsetprober
+    - chardet.cli.chardetect
+    - chardet.universaldetector
+    - chardet.version
   requires:
     - pip
+    - pytest
+    - pytest-xdist
   commands:
     - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - chardetect --help
+    - pytest -n auto test.py -vv --color=yes
 
 about:
   home: https://github.com/chardet/chardet
-  license: NGPL
-  license_family: GPL
+  license: LGPL-2.1-or-later
+  license_family: LGPL
   license_file: LICENSE
   summary: Universal character encoding detector
   description: |
-    chardet is a character encoding auto-detector in Python.
+    Chardet is a character encoding detector for Python. It supports a wide range of encodings,
+    including ASCII, UTF variants, various East Asian encodings (EUC, ISO-2022, Shift_JIS),
+    and many others. Chardet uses statistical models and heuristics to guess the most likely encoding.
   doc_url: https://chardet.readthedocs.org
   dev_url: https://github.com/chardet/chardet
-
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,13 +46,13 @@ test:
   requires:
     - pip
     - pytest
-    - pytest-xdist
+    # - pytest-xdist
   commands:
     - pip check
     - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
     - chardetect --help
-    - pytest -n auto test.py -vv --color=yes  # [not win]
-    - pytest -n auto test.py -vv --color=yes -k "not ({{ skip_broken_tests | join(' or ') }})"  # [win]
+    - pytest test.py -vv --color=yes  # [not win]
+    - pytest test.py -vv --color=yes -k "not ({{ skip_broken_tests | join(' or ') }})"  # [win]
 
 about:
   home: https://github.com/chardet/chardet

--- a/recipe/recipe_conftest.py
+++ b/recipe/recipe_conftest.py
@@ -1,3 +1,11 @@
+# On Windows, some tests were failing because the test data paths in
+# EXPECTED_FAILURES were not normalized to a cross-platform format.
+# As a result, path comparisons between the expected failures list
+# and the actual file paths did not match on Windows.
+# This file fixes the issue by normalizing all paths in EXPECTED_FAILURES
+# (using os.path.normpath), ensuring the tests run correctly on Windows
+# and other platforms.
+
 import os, importlib
 m = importlib.import_module("test")
 m.EXPECTED_FAILURES = {os.path.normpath(p) for p in m.EXPECTED_FAILURES}

--- a/recipe/recipe_conftest.py
+++ b/recipe/recipe_conftest.py
@@ -1,0 +1,3 @@
+import os, importlib
+m = importlib.import_module("test")
+m.EXPECTED_FAILURES = {os.path.normpath(p) for p in m.EXPECTED_FAILURES}


### PR DESCRIPTION
chardet 5.2.0 

**Destination channel:** Defaults

### Links

- [PKG-9141]
- dev_url:        https://github.com/chardet/chardet/tree/5.2.0
- conda_forge:    https://github.com/conda-forge/chardet-feedstock
- pypi:           https://pypi.org/project/chardet/5.2.0
- pypi inspector: https://inspector.pypi.io/project/chardet/5.2.0

### Explanation of changes:

- new version number


[PKG-9141]: https://anaconda.atlassian.net/browse/PKG-9141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ